### PR TITLE
no-text-align-justify

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Create the `.stylelintrc.json` config file (or open the existing one), add `styl
   "rules": {
     "a11y/font-size-is-readable": true,
     "a11y/media-prefers-reduced-motion": true,
-    "a11y/no-outline-none": true,
     "a11y/no-display-none": [true, { "severity": "warning" }],
+    "a11y/no-outline-none": true,
+    "a11y/no-text-align-justify": true,
     "a11y/selector-pseudo-class-focus": true
   }
 }
@@ -30,8 +31,9 @@ Please refer to [stylelint docs](http://stylelint.io/user-guide/) for the detail
 
 - [`font-size-is-readable`](./src/rules/font-size-is-readable/README.md): Disallow font sizes less 15px
 - [`media-prefers-reduced-motion`](./src/rules/media-prefers-reduced-motion/README.md): Require certain styles if the animation or transition in media features
-- [`no-outline-none`](./src/rules/no-outline-none/README.md): Disallow outline clearing
 - [`no-display-none`](./src/rules/no-display-none/README.md): Disallow content hiding with `{ display: none; }` property.
+- [`no-outline-none`](./src/rules/no-outline-none/README.md): Disallow outline clearing
+- [`no-text-align-justify`]('./src/rules/no-text-align-justify/README.md): Disallow content with `{ font-align: justify; }`
 - [`selector-pseudo-class-focus`](./src/rules/selector-pseudo-class-focus/README.md): Require or disallow a pseudo-element to the selectors with :hover
 
 ## Help out

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -2,6 +2,7 @@ import fontSizeIsReadable from './font-size-is-readable';
 import mediaPrefersReducedMotion from './media-prefers-reduced-motion';
 import noDisplayNone from './no-display-none';
 import noOutlineNone from './no-outline-none';
+import noTextAlignJustify from './no-text-align-justify';
 import selectorPseudoClassFocus from './selector-pseudo-class-focus';
 
 export default {
@@ -9,5 +10,6 @@ export default {
   'media-prefers-reduced-motion': mediaPrefersReducedMotion,
   'no-display-none': noDisplayNone,
   'no-outline-none': noOutlineNone,
+  'no-text-align-justify': noTextAlignJustify,
   'selector-pseudo-class-focus': selectorPseudoClassFocus,
 };

--- a/src/rules/no-text-align-justify/README.md
+++ b/src/rules/no-text-align-justify/README.md
@@ -1,0 +1,52 @@
+# justify
+
+Disallow `{ font-align: justify; }` anywhere.
+
+**Sources:**
+
+- [W3C](https://www.w3.org/TR/WCAG20-TECHS/G169.html)
+- [Design for Hackers](https://designforhackers.com/blog/justify-text-html-css/)
+
+## Options
+
+### true
+
+The following pattern are considered violations:
+
+```css
+.foo {
+  font-align: justify;
+}
+```
+
+The following patterns are _not_ considered violations:
+
+```css
+.foo {
+  font-align: center;
+}
+```
+
+```css
+.foo {
+  font-align:  left;
+}
+```
+
+```css
+.foo {
+  font-align:  right;
+}
+```
+
+```css
+.foo {
+  font-align: start;
+}
+```
+
+```css
+.foo {
+  font-align: end;
+}
+```

--- a/src/rules/no-text-align-justify/README.md
+++ b/src/rules/no-text-align-justify/README.md
@@ -1,6 +1,6 @@
-# justify
+# no-text-align-justify
 
-Disallow `{ font-align: justify; }` anywhere.
+Disallow `{ text-align: justify; }` anywhere.
 
 **Sources:**
 
@@ -15,7 +15,7 @@ The following pattern are considered violations:
 
 ```css
 .foo {
-  font-align: justify;
+  text-align: justify;
 }
 ```
 
@@ -23,30 +23,30 @@ The following patterns are _not_ considered violations:
 
 ```css
 .foo {
-  font-align: center;
+  text-align: center;
 }
 ```
 
 ```css
 .foo {
-  font-align:  left;
+  text-align:  left;
 }
 ```
 
 ```css
 .foo {
-  font-align:  right;
+  text-align:  right;
 }
 ```
 
 ```css
 .foo {
-  font-align: start;
+  text-align: start;
 }
 ```
 
 ```css
 .foo {
-  font-align: end;
+  text-align: end;
 }
 ```

--- a/src/rules/no-text-align-justify/__tests__/index.js
+++ b/src/rules/no-text-align-justify/__tests__/index.js
@@ -1,0 +1,42 @@
+import rule, { messages, ruleName } from '../index';
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+
+  accept: [
+    {
+      code: '.foo { font-align: center; }',
+    },
+    {
+      code: '.foo { font-align: left; }',
+    },
+    {
+      code: '.foo { font-align: right; }',
+    },
+    {
+      code: '.foo { font-align: start; }',
+    },
+    {
+      code: '.foo { font-align: end; }',
+    },
+    {
+      code: '.foo { FONT-ALIGN: CENTER; }',
+    },
+  ],
+
+  reject: [
+    {
+      code: '.foo { font-align: justify; }',
+      message: messages.expected('.foo'),
+      line: 1,
+      column: 4,
+    },
+    {
+      code: '.foo { FONT-ALIGN: JUSTIFY; }',
+      message: messages.expected('.foo'),
+      line: 1,
+      column: 4,
+    },
+  ],
+});

--- a/src/rules/no-text-align-justify/__tests__/index.js
+++ b/src/rules/no-text-align-justify/__tests__/index.js
@@ -6,34 +6,34 @@ testRule(rule, {
 
   accept: [
     {
-      code: '.foo { font-align: center; }',
+      code: '.foo { text-align: center; }',
     },
     {
-      code: '.foo { font-align: left; }',
+      code: '.foo { text-align: left; }',
     },
     {
-      code: '.foo { font-align: right; }',
+      code: '.foo { text-align: right; }',
     },
     {
-      code: '.foo { font-align: start; }',
+      code: '.foo { text-align: start; }',
     },
     {
-      code: '.foo { font-align: end; }',
+      code: '.foo { text-align: end; }',
     },
     {
-      code: '.foo { FONT-ALIGN: CENTER; }',
+      code: '.foo { TEXT-ALIGN: CENTER; }',
     },
   ],
 
   reject: [
     {
-      code: '.foo { font-align: justify; }',
+      code: '.foo { text-align: justify; }',
       message: messages.expected('.foo'),
       line: 1,
       column: 4,
     },
     {
-      code: '.foo { FONT-ALIGN: JUSTIFY; }',
+      code: '.foo { TEXT-ALIGN: JUSTIFY; }',
       message: messages.expected('.foo'),
       line: 1,
       column: 4,

--- a/src/rules/no-text-align-justify/index.js
+++ b/src/rules/no-text-align-justify/index.js
@@ -4,7 +4,7 @@ import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
 export const ruleName = 'a11y/no-text-align-justify';
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: selector => `Unexpected using "{ font-align: justify; }" in ${selector}`,
+  expected: selector => `Unexpected using "{ text-align: justify; }" in ${selector}`,
 });
 
 function check(node) {
@@ -15,7 +15,7 @@ function check(node) {
   return !node.nodes.some(
     o =>
       o.type === 'decl' &&
-      o.prop.toLowerCase() === 'font-align' &&
+      o.prop.toLowerCase() === 'text-align' &&
       o.value.toLowerCase() === 'justify'
   );
 }

--- a/src/rules/no-text-align-justify/index.js
+++ b/src/rules/no-text-align-justify/index.js
@@ -1,0 +1,60 @@
+import { utils } from 'stylelint';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule';
+
+export const ruleName = 'a11y/no-text-align-justify';
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: selector => `Unexpected using "{ font-align: justify; }" in ${selector}`,
+});
+
+function check(node) {
+  if (node.type !== 'rule') {
+    return true;
+  }
+
+  return !node.nodes.some(
+    o =>
+      o.type === 'decl' &&
+      o.prop.toLowerCase() === 'font-align' &&
+      o.value.toLowerCase() === 'justify'
+  );
+}
+
+export default function(actual) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, { actual });
+
+    if (!validOptions || !actual) {
+      return;
+    }
+
+    root.walk(node => {
+      let selector = null;
+
+      if (node.type === 'rule') {
+        if (!isStandardSyntaxRule(node)) {
+          return;
+        }
+        selector = node.selector;
+      } else if (node.type === 'atrule' && node.name.toLowerCase() === 'page' && node.params) {
+        selector = node.params;
+      }
+
+      if (!selector) {
+        return;
+      }
+
+      const isAccepted = check(node);
+
+      if (!isAccepted) {
+        utils.report({
+          index: node.lastEach,
+          message: messages.expected(selector),
+          node,
+          ruleName,
+          result,
+        });
+      }
+    });
+  };
+}


### PR DESCRIPTION
I'm write rule for disallowing justified text.

According to W3C we must stop using `text-align: justify` — https://www.w3.org/TR/WCAG20-TECHS/G169.html

Please, review PR and give me feedback.