### PR TITLE
[selector-pseudo-class-focus]: Cannot read property 'match' of undefined

### DIFF
--- a/src/rules/selector-pseudo-class-focus/index.js
+++ b/src/rules/selector-pseudo-class-focus/index.js
@@ -11,6 +11,8 @@ export const messages = utils.ruleMessages(ruleName, {
 });
 
 function check(selector) {
+  if (!selector) return;
+
   if (
     selector.match(/:focus/gi) ||
     (selector.match(/:hover/gi) && selector.match(/:focus/gi)) ||


### PR DESCRIPTION
Closes #11 