### PR TITLE
Fix path for rule `no-spread-text` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please refer to [stylelint docs](http://stylelint.io/user-guide/) for the detail
 |       | [no-display-none](./src/rules/no-display-none/README.md)                                   | Disallow content hiding with `display: none` property                   |
 |       | [no-obsolete-attribute](./src/rules/no-obsolete-attribute/README.md)                       | Disallow obsolete attribute using                                       |
 |       | [no-obsolete-element](./src/rules/no-obsolete-element/README.md)                           | Disallow obsolete selectors using                                       |
-|       | [no-spread-text]('./src/rules/no-spread-text/README.md)                                   | Require width of text in a comfortable range                         |
+|       | [no-spread-text](./src/rules/no-spread-text/README.md)                                    | Require width of text in a comfortable range                         |
 | ⭐️   | [no-outline-none](./src/rules/no-outline-none/README.md)                                   | Disallow outline clearing                                               |
 |       | [no-text-align-justify](./src/rules/no-text-align-justify/README.md)                      | Disallow content with `text-align: justify`                             |
 | ⭐️✒️ | [selector-pseudo-class-focus](./src/rules/selector-pseudo-class-focus/README.md)           | Require or disallow a pseudo-element to the selectors with `:hover`     |


### PR DESCRIPTION
Hello. I found minor bug in README and fixed it.