### PR TITLE
Don’t report errors after applying selector-pseudo-class-focus fix

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -103,6 +103,7 @@ global.testRule = (rule, schema) => {
                 const fixedCode = getOutputCss(output2);
 
                 expect(fixedCode).toBe(testCase.fixed);
+                expect(output2.results[0].warnings.length).toBe(0); // Ensure errors are not reported on fixed code
               });
             });
           });

--- a/src/rules/selector-pseudo-class-focus/index.js
+++ b/src/rules/selector-pseudo-class-focus/index.js
@@ -68,6 +68,7 @@ export default function(actual, _, context) {
             node.selector = `${node.selector}, ${node.selector.replace(/:hover/g, ':focus')}`;
           }
         });
+        return;
       }
 
       if (!isAccepted) {


### PR DESCRIPTION
According to [stylelint autofixing docs](https://stylelint.io/developer-guide/rules#adding-autofixing):

> If context.fix is true, then change root using PostCSS API and return early before report() is called.

