### PR TITLE
Upgrade stylelint to ver 11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "peerDependencies": {
-    "stylelint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+    "stylelint": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -58,7 +58,7 @@
     "lodash": "^4.17.11",
     "prettier": "^1.14.3",
     "rimraf": "^2.6.2",
-    "stylelint": "^10.0.1",
+    "stylelint": "^11.1.1",
     "stylelint-test-rule-tape": "^0.2.0"
   }
 }


### PR DESCRIPTION
After updating stylelint to 11.1.1 I received the following error message

`npm ERR! peer dep missing: stylelint@^8.0.0 || ^9.0.0 || ^10.0.0, required by stylelint-a11y@1.2.1`

Problem was resolved by added 11.0.0 to peerDependencies and increasing version to 11.1.1 in devDependencies.

I ran npm test and found no errors.