### PR TITLE
fix: link to stylelint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ yarn add --dev stylelint stylelint-a11y
 
 Create the `.stylelintrc.json` config file (or open the existing one), add `stylelint-a11y` to the plugins array and the rules you need to the rules list. All rules from stylelint-a11y need to be namespaced with `a11y`.
 
-Please refer to [stylelint docs](https://stylelint.io/user-guide/) for the detailed info on using this linter.
+Please refer to [stylelint docs](https://stylelint.io/user-guide/get-started) for the detailed info on using this linter.
 
 ## Rules
 


### PR DESCRIPTION
Current link (https://stylelint.io/user-guide) is broken. I suggest to change it to the first chapter of the User Guide.