### PR TITLE
Allow content: 'none' and 'initial' for pseudo-elements

### DIFF
--- a/src/rules/content-property-no-static-value/__tests__/index.js
+++ b/src/rules/content-property-no-static-value/__tests__/index.js
@@ -23,6 +23,12 @@ testRule({
     {
       code: ".foo { font-size: '12px'; width: '200px'; }",
     },
+    {
+      code: '.foo::after { content: none; }',
+    },
+    {
+      code: '.foo::after { content: initial; }',
+    },
   ],
 
   reject: [

--- a/src/rules/content-property-no-static-value/index.js
+++ b/src/rules/content-property-no-static-value/index.js
@@ -21,13 +21,12 @@ function check(node) {
   }
 
   return node.nodes.some(o => {
+    const allowedValues = ['\'\'', '""', 'attr(aria-label)', 'none', 'initial'];
     return (
       o.type === 'decl' &&
       o.prop.toLowerCase() === 'content' &&
       isContentPropertyUsedCorrectly(o.parent.selectors) &&
-      (o.value.toLowerCase() === "''" ||
-        o.value.toLowerCase() === '""' ||
-        o.value.toLowerCase() === 'attr(aria-label)')
+      allowedValues.indexOf(o.value.toLowerCase()) > -1
     );
   });
 }


### PR DESCRIPTION
Rule 'content-property-no-static-value' doesn't allow us to have such constructions:

`&::before {
    content: none;
}`

`&::before {
    content: initial;
}`

Since they are widely used for decorative purposes, I'd suggest supporting them.
Also since the list of exceptions became bigger, maybe it makes sense to slightly optimise it.
